### PR TITLE
GREATUK-179 UKEA - Getting to UKEA Landing page

### DIFF
--- a/tests/behavioural/features/steps/ukea_logged_out.py
+++ b/tests/behavioural/features/steps/ukea_logged_out.py
@@ -1,6 +1,7 @@
-from behave import given, then
+from behave import given, then, when
 
 from tests.behavioural.pages.export_academy.landing_page import ExportAcademy
+from tests.behavioural.pages.homepage import HomePage
 
 
 @given('I am on the UKEA landing page')
@@ -16,3 +17,23 @@ def step_ukea_logged_out_landing_page_displayed(context):
     landing_page = ExportAcademy(context)
 
     assert landing_page.signup_cta_visible() is True
+
+
+@given('I am on Great home page')
+def step_visit_ukea_landing_page_from_great_home_page(context):
+    context.great_home_page = HomePage(context)
+    context.great_home_page.get_url()
+    assert context.browser.current_url == context.great_home_page.url
+
+
+@when('I click “Join the UK export academy” card')
+def step_click_card_to_join_ukea(context):
+    context.great_home_page.click_join_the_uk_export_academy_card()
+
+
+@then('I should see UKEA landing page')
+def step_ukea_landing_page_is_loaded_on_browser(context):
+    ukea_landing_page = ExportAcademy(context)
+    ukea_landing_page.get_url()
+    assert context.browser.current_url == ukea_landing_page.url
+    assert ukea_landing_page.signup_cta_visible() is True

--- a/tests/behavioural/features/steps/ukea_logged_out.py
+++ b/tests/behavioural/features/steps/ukea_logged_out.py
@@ -28,7 +28,12 @@ def step_visit_ukea_landing_page_from_great_home_page(context):
 
 @when('I click “Join the UK export academy” card')
 def step_click_card_to_join_ukea(context):
-    context.great_home_page.click_join_the_uk_export_academy_card()
+    great_home_page = HomePage(context)
+    great_home_page.click_join_the_uk_export_academy_card()
+
+    ukea_landing_page = ExportAcademy(context)
+    ukea_landing_page.get_url()
+    assert context.browser.current_url == ukea_landing_page.url
 
 
 @then('I should see UKEA landing page')

--- a/tests/behavioural/features/ukea.feature
+++ b/tests/behavioural/features/ukea.feature
@@ -6,3 +6,9 @@ Feature: UK Export Academy
   Scenario: Verify landing page for non logged in users
     Given I am on the UKEA landing page
     Then I should see a sign up cta
+
+  @Chrome
+  Scenario: Check Landing page is loaded from home page
+    Given I am on Great home page
+    When I click “Join the UK export academy” card
+    Then I should see UKEA landing page

--- a/tests/behavioural/pages/base.py
+++ b/tests/behavioural/pages/base.py
@@ -1,4 +1,4 @@
-from behave.runner import Context as behave_context
+from behave.runner import Context as BehaveContext
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 
@@ -14,7 +14,7 @@ class BasePage(TestHelper):
     POM (Page Object Model) reference: https://www.martinfowler.com/bliki/PageObject.html
     """
 
-    def __init__(self, context: behave_context, path: str):
+    def __init__(self, context: BehaveContext, path: str):
         self.root = ROOT
         self.path = path
         self.url = f'{self.root}{self.path}'

--- a/tests/behavioural/pages/homepage.py
+++ b/tests/behavioural/pages/homepage.py
@@ -14,3 +14,7 @@ class HomePage(BasePage):
 
     def click_export_support_for_uk_businesses_link(self):
         self.do_click_link((By.LINK_TEXT, 'Export support for UK businesses'))
+
+    def click_join_the_uk_export_academy_card(self):
+        self.do_click_link((By.CSS_SELECTOR, 'div.ReactModal__Content a.button.primary-button'))
+        self.do_click_link((By.XPATH, "//span[contains(text(), 'Join the UK Export Academy')]"))

--- a/tests/behavioural/pages/homepage.py
+++ b/tests/behavioural/pages/homepage.py
@@ -16,5 +16,5 @@ class HomePage(BasePage):
         self.do_click_link((By.LINK_TEXT, 'Export support for UK businesses'))
 
     def click_join_the_uk_export_academy_card(self):
-        self.do_click_link((By.CSS_SELECTOR, 'div.ReactModal__Content a.button.primary-button'))
+        self.accept_domestic_cookies()
         self.do_click_link((By.XPATH, "//span[contains(text(), 'Join the UK Export Academy')]"))

--- a/tests/behavioural/utils/test_helpers.py
+++ b/tests/behavioural/utils/test_helpers.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from behave.runner import Context as behave_context
+from behave.runner import Context as BehaveContext
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
@@ -13,7 +13,7 @@ MOBILE_DEVICE = 2
 
 
 class TestHelper:
-    def __init__(self, context: behave_context):
+    def __init__(self, context: BehaveContext):
         self.context = context
         self.driver = context.browser
         self._wait = WebDriverWait(self.driver, 20)


### PR DESCRIPTION
  Scenario: Check Landing page is loaded from home page
        Given I am on Great home page
        When I click “Join the UK export academy” card
        Then I should see UKEA landing page

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-179
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data

### Housekeeping

- [ ] Readme updated
- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Updated security dependencies
- [ ] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
